### PR TITLE
moves dimensionsFilters component beyond the Router scope

### DIFF
--- a/src/components/home/index.js
+++ b/src/components/home/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import DimensionFilters from '../dimensionFilters'
 import Gallery from '../gallery'
 import ImageModal from '../imageModal';
 
@@ -7,7 +6,6 @@ const Home = () => {
 
   return(
     <>
-      <DimensionFilters />
       <Gallery />
       <ImageModal />
     </>

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import Home from './components/home';
+import DimensionFilters from './components/dimensionFilters';
 import { BrowserRouter as Router, Route } from "react-router-dom";
 import "bootstrap/dist/css/bootstrap.min.css";
 import * as serviceWorker from './serviceWorker';
@@ -14,6 +15,7 @@ const Layout = () => {
 
   return(
     <Provider store={store}>
+      <DimensionFilters />
       <Router>
         <Route exact path="/" component={Home} />
         <Route path="/images/:id" component={Home} />


### PR DESCRIPTION
Image thumbnail click uses router to navigate to different url and trigger lightbox to open. When lightbox is exited router goes back to previous route. Both actions rerender Home component. All stored records are properly cached, while DimensionFilter component kept on querying for them again and again to refresh its state.
Moving DimensionsFilters component outside the Router prevents unnecessary rerender of DimensionFilters. I don't see a reason to check for them unless the user goes back to the root and reloads the page. Less requests: less strain on the server.